### PR TITLE
feat(registry): ✨ create icon component for web

### DIFF
--- a/apps/registry/.env.example
+++ b/apps/registry/.env.example
@@ -1,0 +1,2 @@
+# Add the base url of the registry
+# NEXT_PUBLIC_BASE_URL=

--- a/apps/registry/app/page.tsx
+++ b/apps/registry/app/page.tsx
@@ -5,6 +5,7 @@ import { ExampleForm } from "@/components/example-form";
 import { HelloWorld } from "@/components/hello-world";
 import { ModeToggle } from "@/components/mode-toggle";
 import { OpenInV0Button } from "@/components/open-in-v0-button";
+import { PlaceholderIcon } from "@/icons/placeholder";
 
 export default function Home() {
 	return (
@@ -17,6 +18,17 @@ export default function Home() {
 				<ModeToggle className="absolute right-2 top-4" />
 			</header>
 			<main className="flex flex-1 flex-col gap-8">
+				<div className="relative flex min-h-[100px] flex-col gap-4 rounded-lg border p-4">
+					<div className="flex items-center justify-between">
+						<h2 className="text-sm text-outline-gray-5 sm:pl-3">
+							An icon component
+						</h2>
+						<OpenInV0Button name="icon" className="w-fit" />
+					</div>
+					<div className="relative flex min-h-[100px] items-center justify-center">
+						<PlaceholderIcon />
+					</div>
+				</div>
 				<div className="relative flex min-h-[450px] flex-col gap-4 rounded-lg border p-4">
 					<div className="flex items-center justify-between">
 						<h2 className="text-sm text-outline-gray-5 sm:pl-3">

--- a/apps/registry/components/ui/icon.tsx
+++ b/apps/registry/components/ui/icon.tsx
@@ -1,0 +1,54 @@
+import { type ComponentProps } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface IconProps extends ComponentProps<"svg"> {
+	/**
+	 * If it has a label, the icon will be given a role of "img" for accessibility
+	 * If it does not have a label, the icon will be hidden from screen readers
+	 */
+	ariaLabel?: string;
+}
+
+// For accessibility - https://www.smashingmagazine.com/2021/05/accessible-svg-patterns-comparison/
+// Default: aria hidden props are used as the majority of icons are decorative
+export const Icon = ({
+	ariaLabel = undefined,
+	className,
+	children,
+	...props
+}: IconProps) => {
+	const ariaLabelProps: AriaHiddenProps | AriaLabelProps = ariaLabel
+		? {
+				role: "img",
+			}
+		: {
+				"aria-hidden": "true",
+				focusable: "false",
+			};
+
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			className={cn(
+				"inline-block h-[1em] w-[1em] shrink-0 align-middle leading-[1em]",
+				className,
+			)}
+			viewBox="0 0 24 24"
+			{...ariaLabelProps}
+			{...props}
+		>
+			{ariaLabel ? <title>{ariaLabel}</title> : null}
+			{children}
+		</svg>
+	);
+};
+
+interface AriaLabelProps {
+	role: ComponentProps<"svg">["role"];
+}
+
+interface AriaHiddenProps {
+	"aria-hidden": ComponentProps<"svg">["aria-hidden"];
+	focusable: ComponentProps<"svg">["focusable"];
+}

--- a/apps/registry/icons/placeholder.tsx
+++ b/apps/registry/icons/placeholder.tsx
@@ -1,0 +1,21 @@
+import { Icon, IconProps } from "@/components/ui/icon";
+
+type PlaceholderProps = IconProps;
+
+export const PlaceholderIcon = (props: PlaceholderProps) => (
+	<Icon fill="none" viewBox="0 0 16 16" {...props}>
+		<g clipPath="url(#placeholder-icon)">
+			<path
+				fill="currentColor"
+				fillRule="evenodd"
+				d="M7.5.79a.7.7 0 0 1 1 0l6.7 6.71a.7.7 0 0 1 0 1l-3.36 3.35-3.36 3.36a.7.7 0 0 1-.99 0l-3.35-3.36L.79 8.5a.7.7 0 0 1 0-.99l3.36-3.35L7.5.79Zm.5.92L4.85 4.85 1.71 8l3.14 3.15L8 14.29l3.15-3.14L14.29 8 8 1.7Z"
+				clipRule="evenodd"
+			/>
+		</g>
+		<defs>
+			<clipPath id="placeholder-icon">
+				<path fill="currentColor" d="M0 0h16v16H0z" />
+			</clipPath>
+		</defs>
+	</Icon>
+);

--- a/apps/registry/registry/web/default/ui/button.tsx
+++ b/apps/registry/registry/web/default/ui/button.tsx
@@ -5,18 +5,18 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+	"focus-visible:ring-ring inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
 	{
 		variants: {
 			variant: {
 				default:
-					"bg-primary text-primary-foreground shadow hover:bg-primary/90",
+					"bg-primary text-primary-foreground hover:bg-primary/90 shadow",
 				destructive:
-					"bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+					"bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-sm",
 				outline:
-					"border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+					"border-input bg-background hover:bg-accent hover:text-accent-foreground border shadow-sm",
 				secondary:
-					"bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+					"bg-secondary text-secondary-foreground hover:bg-secondary/80 shadow-sm",
 				ghost: "hover:bg-accent hover:text-accent-foreground",
 				link: "text-primary underline-offset-4 hover:underline",
 			},

--- a/apps/registry/registry/web/default/ui/icon.tsx
+++ b/apps/registry/registry/web/default/ui/icon.tsx
@@ -1,0 +1,54 @@
+import { type ComponentProps } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface IconProps extends ComponentProps<"svg"> {
+	/**
+	 * If it has a label, the icon will be given a role of "img" for accessibility
+	 * If it does not have a label, the icon will be hidden from screen readers
+	 */
+	ariaLabel?: string;
+}
+
+// For accessibility - https://www.smashingmagazine.com/2021/05/accessible-svg-patterns-comparison/
+// Default: aria hidden props are used as the majority of icons are decorative
+export const Icon = ({
+	ariaLabel = undefined,
+	className,
+	children,
+	...props
+}: IconProps) => {
+	const ariaLabelProps: AriaHiddenProps | AriaLabelProps = ariaLabel
+		? {
+				role: "img",
+			}
+		: {
+				"aria-hidden": "true",
+				focusable: "false",
+			};
+
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			className={cn(
+				"inline-block h-[1em] w-[1em] shrink-0 align-middle leading-[1em]",
+				className,
+			)}
+			viewBox="0 0 24 24"
+			{...ariaLabelProps}
+			{...props}
+		>
+			{ariaLabel ? <title>{ariaLabel}</title> : null}
+			{children}
+		</svg>
+	);
+};
+
+interface AriaLabelProps {
+	role: ComponentProps<"svg">["role"];
+}
+
+interface AriaHiddenProps {
+	"aria-hidden": ComponentProps<"svg">["aria-hidden"];
+	focusable: ComponentProps<"svg">["focusable"];
+}


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to frappe-ui-react! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10
- [x] Steps in [CONTRIBUTING.md](https://github.com/timelessco/frappe-ui-react/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This pull request introduces several changes to the `apps/registry` project, focusing on adding new components and improving existing ones. The most important changes include the addition of a new `Icon` component, usage of this component in a new `PlaceholderIcon`, and updates to the button styles.

### New Components:

* [`apps/registry/components/ui/icon.tsx`](diffhunk://#diff-c75ed1399abbeb7c53e0a68e4c7a8688e72c6d0689347c31323c2573f3664e82R1-R54): Added a new `Icon` component that includes accessibility features and customizable properties.
* [`apps/registry/icons/placeholder.tsx`](diffhunk://#diff-af72ff71179a755810432629449aca6c4ee69baaa5009ffedd1664e51a6e237fR1-R21): Created a `PlaceholderIcon` component that utilizes the new `Icon` component.

### Component Usage:

* [`apps/registry/app/page.tsx`](diffhunk://#diff-1ff4a0defc36d442eecdab9d8faa235a440d480b1e11adbc8578aff1d4608178R8): Imported and used the `PlaceholderIcon` component within the `Home` function to display an icon with a title and an `OpenInV0Button`. [[1]](diffhunk://#diff-1ff4a0defc36d442eecdab9d8faa235a440d480b1e11adbc8578aff1d4608178R8) [[2]](diffhunk://#diff-1ff4a0defc36d442eecdab9d8faa235a440d480b1e11adbc8578aff1d4608178R21-R31)

### Style Improvements:

* [`apps/registry/registry/web/default/ui/button.tsx`](diffhunk://#diff-f4797b6da7c4ea0b17cd32e60a3073563ce9a63a0f6a2b0fb3139d8816390b99L8-R19): Updated button styles for better visual consistency and accessibility.

### Configuration:

* [`apps/registry/.env.example`](diffhunk://#diff-921d40424f23ba683b66507818612dac7c963bfdaba8d344093557786287f852R1-R2): Added a new environment variable placeholder for the base URL of the registry.