### PR TITLE
feat(docs): ✨ add docs for icon component

### DIFF
--- a/apps/registry/app/docs/content/button-group.mdx
+++ b/apps/registry/app/docs/content/button-group.mdx
@@ -10,7 +10,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 A button group component that allows grouping multiple buttons together, providing a unified interface for actions.
 
-<ComponentPreview component={
+<ComponentPreview name="button-group" component={
   <ButtonGroup>
     <Button>Button 1</Button>
     <Button>Button 2</Button>

--- a/apps/registry/app/docs/content/button.mdx
+++ b/apps/registry/app/docs/content/button.mdx
@@ -10,7 +10,7 @@ import { PlaceholderIcon } from "@/registry/web/default/icons/placeholder";
 
 A button component that follows our design system guidelines with support for different variants, sizes, and icon placements.
 
-<ComponentPreview component={<Button>Click me</Button>}>
+<ComponentPreview name="button" component={<Button>Click me</Button>}>
   <EnhancedCodeBlock language="tsx">
     {`import { Button } from "@/components/ui/button"
 

--- a/apps/registry/app/docs/content/dropdown.mdx
+++ b/apps/registry/app/docs/content/dropdown.mdx
@@ -9,7 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 Accessible dropdown menu component that allows users to select options from a list.
 
-<ComponentPreview component={<DropdownMenuComp />}>
+<ComponentPreview name="dropdown-menu" component={<DropdownMenuComp />}>
  <EnhancedCodeBlock language="tsx">
 	```tsx
 	import {

--- a/apps/registry/app/docs/content/icon.mdx
+++ b/apps/registry/app/docs/content/icon.mdx
@@ -1,0 +1,170 @@
+import { Icon } from "@/components/ui/icon";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ComponentPreview } from "@/components/component-preview";
+import { EnhancedCodeBlock } from "@/components/enhanced-codeblock";
+import { InstallationTabs } from "@/components/installation-tabs";
+import { PackageManagerTabs } from "@/components/package-manager-tabs";
+
+# Icon
+
+A flexible icon component that follows accessibility best practices with support for labels and decorative icons.
+
+<ComponentPreview name="icon" component={<Icon><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="currentColor" fill="none" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" /></Icon>}>
+
+<EnhancedCodeBlock language="tsx">
+{`import { Icon } from "@/components/ui/icon";
+
+export function IconDemo() {
+  return (
+    <Icon>
+      <path
+        d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"
+        stroke="currentColor"
+        fill="none"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Icon>
+  );
+}
+`}
+</EnhancedCodeBlock>
+</ComponentPreview>
+
+## Installation
+
+<InstallationTabs defaultValue="cli">
+  <TabsList>
+    <TabsTrigger value="cli">CLI</TabsTrigger>
+    <TabsTrigger value="manual">Manual</TabsTrigger>
+  </TabsList>
+  <TabsContent value="manual">
+	1. Create a new component file in the `components/ui` directory called `icon.tsx`
+	2. Update the import path according to your project structure
+	3. Copy and paste the following code into the file:
+    <EnhancedCodeBlock language="bash">
+		```tsx
+		import { type ComponentProps } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface IconProps extends ComponentProps<"svg"> {
+	/**
+	 * If it has a label, the icon will be given a role of "img" for accessibility
+	 * If it does not have a label, the icon will be hidden from screen readers
+	 */
+	ariaLabel?: string;
+}
+
+// For accessibility - https://www.smashingmagazine.com/2021/05/accessible-svg-patterns-comparison/
+// Default: aria hidden props are used as the majority of icons are decorative
+export const Icon = ({
+	ariaLabel = undefined,
+	className,
+	children,
+	...props
+}: IconProps) => {
+	const ariaLabelProps: AriaHiddenProps | AriaLabelProps = ariaLabel
+		? {
+				role: "img",
+			}
+		: {
+				"aria-hidden": "true",
+				focusable: "false",
+			};
+
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			className={cn(
+				"inline-block h-[1em] w-[1em] shrink-0 align-middle leading-[1em]",
+				className,
+			)}
+			viewBox="0 0 24 24"
+			{...ariaLabelProps}
+			{...props}
+		>
+			{ariaLabel ? <title>{ariaLabel}</title> : null}
+			{children}
+		</svg>
+	);
+};
+
+interface AriaLabelProps {
+	role: ComponentProps<"svg">["role"];
+}
+
+interface AriaHiddenProps {
+	"aria-hidden": ComponentProps<"svg">["aria-hidden"];
+	focusable: ComponentProps<"svg">["focusable"];
+}
+
+		```
+	</EnhancedCodeBlock>
+  </TabsContent>
+  <TabsContent value="cli">
+    <PackageManagerTabs defaultValue="npm">
+      <TabsList>
+        <TabsTrigger value="npm">npm</TabsTrigger>
+        <TabsTrigger value="pnpm">pnpm</TabsTrigger>
+				<TabsTrigger value="yarn">yarn</TabsTrigger>
+      </TabsList>
+      <TabsContent value="npm">
+        <EnhancedCodeBlock language="bash">
+          npx shadcn@latest add "https://frappe-ui-react.tmls.dev/registry/icon"
+        </EnhancedCodeBlock>
+      </TabsContent>
+      <TabsContent value="pnpm">
+        <EnhancedCodeBlock language="bash">
+          pnpm dlx shadcn@latest add "https://frappe-ui-react.tmls.dev/registry/icon"
+        </EnhancedCodeBlock>
+      </TabsContent>
+		<TabsContent value="yarn">
+        <EnhancedCodeBlock language="bash">
+          yarn shadcn@latest add "https://frappe-ui-react.tmls.dev/registry/icon"
+        </EnhancedCodeBlock>
+      </TabsContent>
+    </PackageManagerTabs>
+  </TabsContent>
+</InstallationTabs>
+
+
+### Usage
+
+#### Decorative Icon (Default)
+<ComponentPreview component={<Icon><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="currentColor" fill="none" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" /></Icon>}>
+<EnhancedCodeBlock language="tsx">
+{`import { Icon } from "@/components/ui/icon";
+
+export function IconDemo() {
+  return (
+			<>
+				<Icon>
+					<path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="currentColor" fill="none" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+				</Icon>
+			</>
+  );
+}
+`}
+</EnhancedCodeBlock>
+</ComponentPreview>
+#### Icon with Aria Label
+
+<ComponentPreview component={<Icon ariaLabel="Icon with label"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="currentColor" fill="none" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" /></Icon>}>
+<EnhancedCodeBlock language="tsx">
+{`import { Icon } from "@/components/ui/icon";
+
+export function IconDemo() {
+  return (
+    <>
+      <Icon ariaLabel="Icon with label">
+        <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="currentColor" fill="none" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+      </Icon>
+    </>
+  );
+}
+`}
+</EnhancedCodeBlock>
+</ComponentPreview>
+

--- a/apps/registry/components/component-preview.tsx
+++ b/apps/registry/components/component-preview.tsx
@@ -6,13 +6,17 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EnhancedCodeBlock } from "@/components/enhanced-codeblock";
 import { cn } from "@/lib/utils";
 
+import { OpenInV0Button } from "./open-in-v0-button";
+
 interface ComponentPreviewProps extends React.HTMLAttributes<HTMLDivElement> {
 	children: React.ReactNode;
 	className?: string;
 	component: React.ReactNode;
+	name: string;
 }
 
 export function ComponentPreview({
+	name,
 	component,
 	children,
 	className,
@@ -29,6 +33,9 @@ export function ComponentPreview({
 					value="preview"
 					className="rounded-lg border p-6 shadow-sm"
 				>
+					<div className="flex items-center justify-end">
+						<OpenInV0Button name={name} />
+					</div>
 					<div className="flex min-h-[350px] items-center justify-center">
 						{component}
 					</div>


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #62
- [x] Steps in [CONTRIBUTING.md](https://github.com/timelessco/frappe-ui-react/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

- Update ComponentPreview to accept a name prop for better identification
- Modify documentation files for button, dropdown, and button-group components to include names in previews
- Add new icon component documentation with detailed usage instructions