### PR TITLE
feat(input): ✨ create input component for web

### DIFF
--- a/apps/registry/app/page.tsx
+++ b/apps/registry/app/page.tsx
@@ -14,6 +14,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
+import { Input } from "@/components/ui/input";
 import { DropdownMenuComp } from "@/components/dropdown-menu-comp";
 import { ModeToggle } from "@/components/mode-toggle";
 import { OpenInV0Button } from "@/components/open-in-v0-button";
@@ -34,6 +35,60 @@ export default function Home() {
 				<ModeToggle className="absolute right-2 top-4" />
 			</header>
 			<main className="flex flex-1 flex-col gap-8">
+				{/* Complete Input Component */}
+				<div className="relative flex flex-col gap-4 rounded-lg border p-4">
+					<div className="flex items-center justify-between">
+						<h2 className="text-sm text-outline-gray-5 sm:pl-3">
+							An input component
+						</h2>
+						<OpenInV0Button name="input" className="w-fit" />
+					</div>
+					<div className="relative flex flex-col items-center justify-center gap-4">
+						{/* Outline inputs */}
+						{["subtle", "outline"].map((variant) =>
+							["sm", "md", "lg", "xl"].map((size) => (
+								<div
+									className="flex w-full flex-col items-center justify-center gap-4 sm:w-[600px]"
+									key={`${variant}-${size}`}
+								>
+									<div className="flex w-full flex-wrap items-center justify-center gap-2 sm:flex-nowrap">
+										<Input
+											variant={variant as "outline" | "subtle"}
+											size={size as "lg" | "md" | "sm" | "xl"}
+											placeholder="Type here..."
+										/>
+										<Input
+											variant={variant as "outline" | "subtle"}
+											size={size as "lg" | "md" | "sm" | "xl"}
+											placeholder="Type here..."
+											prefix={<PlaceholderIcon />}
+										/>
+									</div>
+									<div
+										className="flex w-full flex-wrap items-center justify-center gap-2 sm:flex-nowrap"
+										key={`${variant}-${size}`}
+									>
+										<Input
+											variant={variant as "outline" | "subtle"}
+											size={size as "lg" | "md" | "sm" | "xl"}
+											disabled
+											placeholder="Disabled..."
+											suffix={<PlaceholderIcon />}
+										/>
+										<Input
+											variant={variant as "outline" | "subtle"}
+											invalid
+											size={size as "lg" | "md" | "sm" | "xl"}
+											placeholder="Invalid..."
+											prefix={<PlaceholderIcon />}
+											suffix={<PlaceholderIcon />}
+										/>
+									</div>
+								</div>
+							)),
+						)}
+					</div>
+				</div>
 				{/* Badge Component */}
 				<div className="relative flex flex-col gap-4 rounded-lg border p-4">
 					<div className="flex items-center justify-between">
@@ -337,7 +392,6 @@ export default function Home() {
 						</div>
 					</div>
 				</div>
-
 				{/* Avatar Group Component */}
 				<div className="relative flex flex-col gap-4 rounded-lg border p-4">
 					<div className="flex items-center justify-between">
@@ -481,7 +535,6 @@ export default function Home() {
 						</AvatarLabelGroup>
 					</div>
 				</div>
-
 				{/* Avatar Component */}
 				<div className="relative flex flex-col gap-4 rounded-lg border p-4">
 					<div className="flex items-center justify-between">
@@ -596,7 +649,6 @@ export default function Home() {
 						</div>
 					</div>
 				</div>
-
 				{/* Button Component */}
 				<div className="relative flex flex-col gap-8 rounded-lg border px-4 pb-8 pt-4">
 					<div className="flex items-center justify-between">
@@ -1041,7 +1093,6 @@ export default function Home() {
 					</div>
 					{/* ghost buttons ends */}
 				</div>
-
 				{/* Button Group Component */}
 				<div className="relative flex min-h-[100px] flex-col gap-4 rounded-lg border p-4">
 					<div className="flex items-center justify-between">
@@ -1077,7 +1128,6 @@ export default function Home() {
 						</ButtonGroup>
 					</div>
 				</div>
-
 				{/* Dropdown Menu Component */}
 				<div className="relative flex min-h-[100px] flex-col gap-4 rounded-lg border p-4">
 					<div className="flex items-center justify-between">
@@ -1090,7 +1140,6 @@ export default function Home() {
 						<DropdownMenuComp />
 					</div>
 				</div>
-
 				{/* Icon Component */}
 				<div className="relative flex flex-col gap-4 rounded-lg border p-4">
 					<div className="flex items-center justify-between">

--- a/apps/registry/components/ui/input.tsx
+++ b/apps/registry/components/ui/input.tsx
@@ -1,22 +1,188 @@
+"use client";
+
 import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-	({ className, type, ...props }, ref) => {
+const inputVariants = cva(
+	"peer inline-flex w-full appearance-none items-center justify-center outline-none transition focus:text-ink-gray-7 focus:ring-2 focus:ring-focus-light-default disabled:cursor-not-allowed disabled:select-none",
+	{
+		variants: {
+			size: {
+				sm: "h-7 rounded-ef-4  px-ef-8 py-ef-6 text-ef-base font-ef-regular leading-[115%] tracking-[0.07px]",
+				md: "h-8 rounded-ef-4 px-ef-10 py-ef-8 text-ef-base font-ef-regular leading-[115%] tracking-[0.07px]",
+				lg: "h-10 rounded-ef-5 px-ef-12 py-ef-11 text-ef-base font-ef-regular leading-[115%] tracking-[0.07px]",
+				xl: "h-10 rounded-ef-5 px-ef-14 py-[9.5px] text-ef-xl font-ef-regular leading-[115%] tracking-[0.18px]",
+			},
+			variant: {
+				subtle:
+					"bg-surface-gray-2 text-ink-gray-4 placeholder:text-ink-gray-4  focus:bg-surface-white ",
+				outline:
+					"border border-outline-gray-2 bg-surface-white placeholder:text-ink-gray-4",
+			},
+			disabled: {
+				true: "bg-surface-gray-1 text-ink-gray-3 placeholder:text-ink-gray-3",
+				false:
+					"active:text-ink-gray-7 active:ring-2 active:ring-focus-light-default",
+			},
+			invalid: {
+				true: "",
+				false: "",
+			},
+		},
+		compoundVariants: [
+			{
+				variant: "subtle",
+				disabled: false,
+				className: "hover:bg-surface-gray-3 ",
+			},
+			{
+				variant: "outline",
+				disabled: false,
+				className: "hover:shadow-[0px_1px_4px_0px_rgba(0,0,0,0.10)]",
+			},
+			{
+				variant: "subtle",
+				invalid: true,
+				className: "bg-surface-red-2",
+			},
+			{
+				variant: "outline",
+				invalid: true,
+				className: "border-outline-red-3",
+			},
+		],
+		defaultVariants: {
+			size: "sm",
+			variant: "subtle",
+		},
+	},
+);
+
+const prefixVariants = cva(
+	"pointer-events-none absolute inset-y-0 left-0 flex items-center justify-center bg-transparent text-ink-gray-4 placeholder:text-ink-gray-4 peer-focus:text-ink-gray-7",
+	{
+		variants: {
+			size: {
+				sm: "px-ef-8",
+				md: "pl-ef-10 pr-ef-8",
+				lg: "pl-ef-12 pr-ef-8",
+				xl: "pl-ef-14 pr-ef-10",
+			},
+		},
+	},
+);
+
+const suffixVariants = cva(
+	"pointer-events-none absolute inset-y-0 right-0 flex items-center justify-center bg-transparent text-ink-gray-4 placeholder:text-ink-gray-4 peer-focus:text-ink-gray-7",
+	{
+		variants: {
+			size: {
+				sm: "pl-ef-13 pr-ef-8",
+				md: "pl-ef-13 pr-ef-10",
+				lg: "pl-ef-13 pr-ef-12",
+				xl: "pl-ef-13 pr-ef-14",
+			},
+		},
+	},
+);
+
+export interface InputProps
+	extends Omit<
+			React.InputHTMLAttributes<HTMLInputElement>,
+			"disabled" | "prefix" | "size"
+		>,
+		VariantProps<typeof inputVariants> {
+	asChild?: boolean;
+	prefix?: React.ReactNode;
+	suffix?: React.ReactNode;
+}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+	(
+		{
+			className,
+			type,
+			size = "md",
+			variant = "subtle",
+			invalid = false,
+			disabled = false,
+			asChild = false,
+			prefix,
+			suffix,
+			...props
+		},
+		ref,
+	) => {
+		const Comp = asChild ? Slot : "input";
+
+		const [_, setHasPaddingCalculated] = React.useState(false);
+		const inputInlineStyles = React.useRef<Record<string, number>>({});
+		const prefixRef = React.useRef<HTMLDivElement>(null);
+		const suffixRef = React.useRef<HTMLDivElement>(null);
+
+		React.useLayoutEffect(() => {
+			let key = "";
+
+			const prefixElement = prefixRef.current;
+			const suffixElement = suffixRef.current;
+
+			if (prefix && prefixElement) {
+				key = "paddingLeft";
+
+				if (!key) return;
+				inputInlineStyles.current[key] =
+					prefixElement.getBoundingClientRect().width;
+			}
+
+			if (suffix && suffixElement) {
+				key = "paddingRight";
+
+				if (!key) return;
+				inputInlineStyles.current[key] =
+					suffixElement.getBoundingClientRect().width;
+			}
+
+			setHasPaddingCalculated(true);
+		}, [prefix, suffix]);
+
 		return (
-			<input
-				type={type}
-				className={cn(
-					"flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-					className,
+			<div className="relative inline-flex w-full">
+				<Comp
+					type={type}
+					className={cn(
+						inputVariants({
+							size,
+							variant,
+							invalid,
+							disabled,
+							className,
+						}),
+					)}
+					disabled={disabled ?? false}
+					ref={ref}
+					style={{ ...inputInlineStyles.current }}
+					{...props}
+				/>
+
+				{prefix && (
+					<div ref={prefixRef} className={cn(prefixVariants({ size }))}>
+						{prefix}
+					</div>
 				)}
-				ref={ref}
-				{...props}
-			/>
+
+				{suffix && (
+					<div ref={suffixRef} className={cn(suffixVariants({ size }))}>
+						{suffix}
+					</div>
+				)}
+			</div>
 		);
 	},
 );
+
 Input.displayName = "Input";
 
 export { Input };


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to frappe-ui-react! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #79
- [x] Steps in [CONTRIBUTING.md](https://github.com/timelessco/frappe-ui-react/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This pull request introduces a new `Input` component and integrates it into the `Home` page. The changes include importing the `Input` component, adding the component to the page, and defining its styles and variants.

### Integration of `Input` Component:

* [`apps/registry/app/page.tsx`](diffhunk://#diff-1ff4a0defc36d442eecdab9d8faa235a440d480b1e11adbc8578aff1d4608178R17): Added import for `Input` component and integrated it into the `Home` page with various examples showcasing different sizes, variants, and states such as disabled and invalid. [[1]](diffhunk://#diff-1ff4a0defc36d442eecdab9d8faa235a440d480b1e11adbc8578aff1d4608178R17) [[2]](diffhunk://#diff-1ff4a0defc36d442eecdab9d8faa235a440d480b1e11adbc8578aff1d4608178R38-R91)

### Definition of `Input` Component:

* [`apps/registry/components/ui/input.tsx`](diffhunk://#diff-347ac3d7536a6e3523beba15ebf600da2588833a3300f11ff49c2a0ec15456a2R1-R185): Created the `Input` component with support for different sizes, variants, and states. Added support for prefix and suffix icons, and included styles using `class-variance-authority`.

### Code Cleanup:

* [`apps/registry/app/page.tsx`](diffhunk://#diff-1ff4a0defc36d442eecdab9d8faa235a440d480b1e11adbc8578aff1d4608178L340): Removed unnecessary empty lines to improve code readability. [[1]](diffhunk://#diff-1ff4a0defc36d442eecdab9d8faa235a440d480b1e11adbc8578aff1d4608178L340) [[2]](diffhunk://#diff-1ff4a0defc36d442eecdab9d8faa235a440d480b1e11adbc8578aff1d4608178L484) [[3]](diffhunk://#diff-1ff4a0defc36d442eecdab9d8faa235a440d480b1e11adbc8578aff1d4608178L599) [[4]](diffhunk://#diff-1ff4a0defc36d442eecdab9d8faa235a440d480b1e11adbc8578aff1d4608178L1044) [[5]](diffhunk://#diff-1ff4a0defc36d442eecdab9d8faa235a440d480b1e11adbc8578aff1d4608178L1080) [[6]](diffhunk://#diff-1ff4a0defc36d442eecdab9d8faa235a440d480b1e11adbc8578aff1d4608178L1093)