### PR TITLE
refactor(registry): ♻️ remove unnecessary meta fields from web components

### DIFF
--- a/apps/registry/registry.json
+++ b/apps/registry/registry.json
@@ -48,10 +48,7 @@
 					"type": "registry:ui"
 				}
 			],
-			"categories": ["primitives"],
-			"meta": {
-				"native": true
-			}
+			"categories": ["primitives"]
 		},
 		{
 			"name": "button-group",
@@ -69,10 +66,7 @@
 					"type": "registry:ui"
 				}
 			],
-			"categories": ["primitives"],
-			"meta": {
-				"native": true
-			}
+			"categories": ["primitives"]
 		},
 		{
 			"name": "dropdown",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #61
- [x] Steps in [CONTRIBUTING.md](https://github.com/timelessco/frappe-ui-react/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

- Simplify registry.json by removing the 'meta' field from components
- Maintain 'categories' structure for consistency
- Improve readability and maintainability of the registry configuration